### PR TITLE
serde-codec feature flag necessary to reveal Cid type that implements Serialize Deserialize

### DIFF
--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -13,7 +13,7 @@ hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 sp-trie = { version = "2.0.0-rc6", default-features = false }
 thiserror = { version = "1.0.20", optional = true }
-tiny-multihash = { version = "0.4.1", default-features = false, features = ["blake2b", "scale-codec"] }
+tiny-multihash = { version = "0.4.1", default-features = false, features = ["blake2b", "scale-codec", "serde-codec"] }
 tiny-cid = { version = "0.2.0", default-features = false, features = ["scale-codec", "serde-codec"] }
 
 [dev-dependencies]

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -14,7 +14,7 @@ hash256-std-hasher = { version = "0.15.2", default-features = false }
 sp-trie = { version = "2.0.0-rc6", default-features = false }
 thiserror = { version = "1.0.20", optional = true }
 tiny-multihash = { version = "0.4.1", default-features = false, features = ["blake2b", "scale-codec"] }
-tiny-cid = { version = "0.2.0", default-features = false, features = ["scale-codec"] }
+tiny-cid = { version = "0.2.0", default-features = false, features = ["scale-codec", "serde-codec"] }
 
 [dev-dependencies]
 async-std = { version = "1.6.3", features = ["attributes"] }


### PR DESCRIPTION
I haven't been able to confirm that this works yet. I think Cargo.toml isn't recognizing my attempt to refer to this branch...